### PR TITLE
maintain unique searchHistory entries

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -22,17 +22,18 @@ export interface SearchResult {
 
 interface SearchProps {
   handleSearchResults:  (results: SearchResult[]) => void;
+ 
 }
 
-
+const defaultFilters = {
+  sortBy: "",
+  from: "",
+  to: "",
+}
 export default function SearchBar({ handleSearchResults }: SearchProps) {
   const [search, { error }] = useMutation(SEARCH)
   const [query, setQuery] = useState("");
-  const [filters, setFilters] = useState({
-    sortBy: "",
-    from: "",
-    to: "",
-  });
+  const [filters, setFilters] = useState(defaultFilters);
   const [showFilters, setShowFilters] = useState(false);
 
   // Get today's date and a date 30 days ago in YYYY-MM-DD format.
@@ -41,7 +42,14 @@ export default function SearchBar({ handleSearchResults }: SearchProps) {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   const minDate = thirtyDaysAgo.toISOString().split("T")[0];
 
+  const clearFilters = () => {
+    setFilters(defaultFilters)
+  }
+
   const handleInputChange = (_: any, { value }: any) => {
+    if (!value.startsWith(query)) {
+      clearFilters()
+    }
     setQuery(value);
     if (value.trim() === "") {
       // onSearch("", filters);
@@ -59,6 +67,7 @@ export default function SearchBar({ handleSearchResults }: SearchProps) {
 
   const handleSearch = async () => {
     if (!query.trim()) {
+      clearFilters()
       // onSearch("", filters);
       return;
     }

--- a/server/src/schemas/resolvers.ts
+++ b/server/src/schemas/resolvers.ts
@@ -134,14 +134,21 @@ const resolvers = {
 			// Create a new instance of SearchParams but convert it to a plain object
 			const paramsInstance = new SearchParams({ ...args });
 			const params = paramsInstance.toObject(); // Removes Mongoose metadata like `_id`
-		
-			// Prevent duplicate search history entries using `$addToSet`
-			await User.findByIdAndUpdate(
-				user._id,
-				{ $addToSet: { searchHistory: params } }, // Ensures uniqueness
-				{ new: true }
-			);
-		
+			const index = user.searchHistory.findIndex(element => element.searchTerms == params.searchTerms)
+			if (index == 0) {
+				user.searchHistory[index] = params;
+			}
+			else if (index > 0) {
+				for (let i = index; i > 0; --i) {
+					user.searchHistory[i] = user.searchHistory[i - 1]
+				}
+				user.searchHistory[0] = params
+			}
+			else {
+				user.searchHistory.push(params);
+			}
+			user.save();
+					
 			return fetchSearch(args);
 		},				
 		addFavorite: async(_parent: unknown, args: AddFavoriteArgs, context: Context): Promise<User> => {


### PR DESCRIPTION
resolvers search modified to ensure only one history entry exists for each searchTerms. Will push current searchTerms entry to top of history and update its metadata.
SearchBar component modified to clear filters on input change unless existing search terms is a prefix of new value